### PR TITLE
Use growpart instead of parted for auto expanding the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **note**
+> ![NOTE]
 > Please visit https://github.com/radxa/backup-sh
 
 # Rockpi-toolkit
@@ -14,6 +14,7 @@ _It may work for unofficial systems, but we do not provide any technical support
 ### Install
 
 ```bash
+linaro@rockpi:~ $ sudo apt install cloud-guest-utils # For auto-expanding the image
 linaro@rockpi:~ $ curl -sL https://rock.sh/rockpi-backup -o rockpi-backup.sh
 linaro@rockpi:~ $ chmod +x rockpi-backup.sh
 ```

--- a/rockpi-backup.sh
+++ b/rockpi-backup.sh
@@ -129,7 +129,7 @@ ROOT_DEV=\`lsblk -no PATH,MOUNTPOINT | grep \"/$\" | awk '{print \$1}'\`
 # fix disk size
 echo w | fdisk \$ROOT_PART
 
-echo -e \"resizepart \$ROOT_PART_NO 100%\ny\" | parted ---pretend-input-tty \$ROOT_PART
+growpart \$ROOT_PART \$ROOT_PART_NO
 
 # ext4 part only
 resize2fs \$ROOT_DEV


### PR DESCRIPTION
The original backup script works great for storing the SD card contents in a disk image file. However, when I wrote the image back to the new SD card, the filesystem did not automatically expand on the first boot.

The service that runs the auto-expand script on the first boot (https://github.com/radxa/backup-sh/blob/7a464e3748cc7db5fa1e9796420f48ac8e5300b5/rockpi-backup.sh#L105) competed successfully, but the partition did not take up the whole 32 GB of the SD card.

I don't know exactly what seems to be the problem, but it is probably somewhere in these two lines:
https://github.com/radxa/backup-sh/blob/7a464e3748cc7db5fa1e9796420f48ac8e5300b5/rockpi-backup.sh#L130-L132
Both commands run without errors. However, `resizepart ... 100%` writes the end of the current partition instead of the end of the available free space - resulting in no changes to the partition size.

I found a tool `growpart` from the Ubuntu package `cloud-guest-utils` that seems to do a better job (also reported [here](https://unix.stackexchange.com/a/436069)) and replaced the corresponding `parted` line with this command. The only downside of this approach is that **`growpart` must be installed on the system that is being backed up before the backup**.

My filesystem expanded automatically on the first boot without any noticeable problems. After the first boot, I removed the SD card from Rock Pi, inserted it into my computer, and ran a filesystem check in GParted. It didn't detect any errors. 

Tested with:
- SanDisk Ultra A1 32GB SD card
- Rock Pi S, v13
- Official Ubuntu 20.04 [image](https://wiki.radxa.com/RockpiS/downloads)